### PR TITLE
feat: Add LineItems property and QuoteLineItemCaptureModel class

### DIFF
--- a/src/LightstonePlatform.Products/Models/ProductFlowInstanceMetadata.cs
+++ b/src/LightstonePlatform.Products/Models/ProductFlowInstanceMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace LightstonePlatform.Products.Models
 {
@@ -6,6 +7,7 @@ namespace LightstonePlatform.Products.Models
     [Serializable]
     public class ProductFlowInstanceMetadata: ProductFlowInstanceMetadataBase
     {
+        public List<QuoteLineItemCaptureModel> LineItems { get; set; } = new List<QuoteLineItemCaptureModel>();
         public UIMetaData UI { get; set; } = new UIMetaData();
     }
 }

--- a/src/LightstonePlatform.Products/Models/QuoteLineItemCaptureModel.cs
+++ b/src/LightstonePlatform.Products/Models/QuoteLineItemCaptureModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LightstonePlatform.Products.Models
+{
+    [Serializable]
+    public class QuoteLineItemCaptureModel
+    {
+        public string Description { get; set; }
+        public int Quantity { get; set; }
+        public string ProductCode { get; set; }
+        public Guid? UniqueReference { get; set; }
+    }
+}


### PR DESCRIPTION
Added a `LineItems` property to the `ProductFlowInstanceMetadata` class to store a collection of `QuoteLineItemCaptureModel` objects. Introduced the `QuoteLineItemCaptureModel` class with properties for description, quantity, product code, and an optional unique reference. Updated necessary `using` directives to support the new class and its functionality.